### PR TITLE
Cap number of partitions to 500 to avoid exceeding taskValues limit

### DIFF
--- a/resources/jdbc_bulk_ingest_job.yml
+++ b/resources/jdbc_bulk_ingest_job.yml
@@ -70,7 +70,7 @@ resources:
               min_retry_interval_millis: 0
       max_concurrent_runs: 1
       parameters:
-        - default: sql
+        - default: python
           name: lang
         - default: ckoester_sql_server
           name: src_catalog

--- a/src/get_query_list.ipynb
+++ b/src/get_query_list.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -87,13 +87,18 @@
    },
    "outputs": [],
    "source": [
-    "partition_spec = get_partition_spec_sqlserver(src_catalog, src_schema, src_table, partition_col, 100)\n",
+    "partition_spec = get_partition_spec_sqlserver(src_catalog, src_schema, src_table, partition_col, 200)\n",
+    "\n",
+    "# Cap the size of num_partitions to avoid exceeding the 48 KiB limit of taskValues\n",
+    "# https://docs.databricks.com/en/jobs/share-task-context.html\n",
+    "partition_spec['num_partitions'] = min(partition_spec['num_partitions'], 500)\n",
+    "\n",
     "print(partition_spec)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -116,14 +121,13 @@
     "    **partition_spec\n",
     ")\n",
     "\n",
-    "for i in partition_queries:\n",
-    "    i[\"full_query\"] = f\"insert into {tgt_catalog}.{tgt_schema}.{tgt_table} {i['src_query']}\"\n",
+    "queries_list = [i['where_clause'] for i in partition_queries]\n",
     "\n",
-    "for i in partition_queries:\n",
-    "    print(i[\"full_query\"])\n",
+    "for i in queries_list:\n",
+    "    print(i)\n",
     "\n",
     "# Assign query list to job task value. The list can be iterated in a subsequent task.\n",
-    "dbutils.jobs.taskValues.set(key=\"partition_queries\", value=partition_queries)"
+    "dbutils.jobs.taskValues.set(key=\"partition_queries\", value=queries_list)"
    ]
   }
  ],

--- a/src/jdbc_bulk_ingest/main.py
+++ b/src/jdbc_bulk_ingest/main.py
@@ -166,7 +166,7 @@ def generate_partition_queries(catalog, schema, table, partition_column, lower_b
             whereClause = f'{uBound} or {partition_column} is null'
         else:
             whereClause = f'{lBound} and {uBound}'
-        queryList.append({'lower_bound' : int(lBoundValue), 'upper_bound' : int(uBoundValue) - 1, 'src_query' : f'select * from {catalog}.{schema}.{table} where {whereClause}'})
+        queryList.append({'lower_bound' : int(lBoundValue), 'upper_bound' : int(uBoundValue) - 1, 'where_clause' : whereClause})
         i = i + 1
         
     return queryList

--- a/src/run_query_py.ipynb
+++ b/src/run_query_py.ipynb
@@ -17,7 +17,28 @@
    },
    "outputs": [],
    "source": [
-    "dbutils.widgets.text('qry', '', 'qry')"
+    "dbutils.widgets.text('where_clause', '', 'where_clause')\n",
+    "dbutils.widgets.text('src_catalog', '', '01 Source Catalog')\n",
+    "dbutils.widgets.text('src_schema', '', '02 Source Schema')\n",
+    "dbutils.widgets.text('src_table', '', '03 Source Table')\n",
+    "dbutils.widgets.text('tgt_catalog', '', '05 Target Catalog')\n",
+    "dbutils.widgets.text('tgt_schema', '', '06 Target Schema')\n",
+    "dbutils.widgets.text('tgt_table', '', '07 Target Table')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "where_clause = dbutils.widgets.get('where_clause')\n",
+    "src_catalog = dbutils.widgets.get('src_catalog')\n",
+    "src_schema = dbutils.widgets.get('src_schema')\n",
+    "src_table = dbutils.widgets.get('src_table')\n",
+    "tgt_catalog = dbutils.widgets.get('tgt_catalog')\n",
+    "tgt_schema = dbutils.widgets.get('tgt_schema')\n",
+    "tgt_table = dbutils.widgets.get('tgt_table')"
    ]
   },
   {
@@ -37,7 +58,11 @@
    },
    "outputs": [],
    "source": [
-    "qry = dbutils.widgets.get('qry')\n",
+    "spark.sql(f'use catalog {tgt_catalog}')\n",
+    "spark.sql(f'use schema {tgt_schema}')\n",
+    "\n",
+    "# Add build full statement\n",
+    "qry = f'insert into {tgt_catalog}.{tgt_schema}.{tgt_table} select * from {src_catalog}.{src_schema}.{src_table} where {where_clause}'\n",
     "\n",
     "print('Query:')\n",
     "print(qry)\n",


### PR DESCRIPTION
taskValues in dbutils has a [limit of 48 KiB](https://docs.databricks.com/en/jobs/share-task-context.html), which limits the size of the collection that can used with a foreach task. This pull request minimizes the amount of data in the collection and caps it at 500.