### PR TITLE
Add support for PostgreSQL

### DIFF
--- a/config/postgresql_jdbc.json
+++ b/config/postgresql_jdbc.json
@@ -1,0 +1,8 @@
+{
+    "host": "ckoester.postgres.database.azure.com",
+    "port": "5432",
+    "database": "postgres",
+    "secret_scope": "chris_koester",
+    "secret_key_user": "jdbc_user",
+    "secret_key_pwd": "jdbc_pwd"
+}

--- a/resources/lakefed_job.yml
+++ b/resources/lakefed_job.yml
@@ -38,21 +38,26 @@ resources:
       parameters:
         - name: lang
           default: python
+        - name: src_type
+          default: sqlserver
         - name: src_catalog
           default: ckoester_sql_server
         - name: src_schema
           default: dbo
         - name: src_table
           default: partitioned_queries_src
+        - name: partition_col
+          default: customer_id
+        - name: partition_size_mb
+          default: 256
+        - name: concurrency
+          default: 8
         - name: tgt_catalog
           default: main
         - name: tgt_schema
           default: chris_koester
         - name: tgt_table
           default: partitioned_queries_tgt
-        - name: partition_col
-          default: customer_id
-      edit_mode: EDITABLE
     lakehouse_federation_ingest_lvl2:
       name: "Lakehouse Federation Ingest Lvl2"
       tasks:
@@ -115,6 +120,8 @@ resources:
           default: dbo
         - name: src_table
           default: partitioned_queries_src
+        - name: concurrency
+          default: 8
         - name: tgt_catalog
           default: main
         - name: tgt_schema

--- a/src/get_partition_list.ipynb
+++ b/src/get_partition_list.ipynb
@@ -17,13 +17,15 @@
    },
    "outputs": [],
    "source": [
+    "dbutils.widgets.dropdown('src_type', 'sqlserver', ['sqlserver', 'postgresql', 'delta'], '01 Source Type')\n",
     "dbutils.widgets.text('src_catalog', '', '01 Source Catalog')\n",
     "dbutils.widgets.text('src_schema', '', '02 Source Schema')\n",
     "dbutils.widgets.text('src_table', '', '03 Source Table')\n",
     "dbutils.widgets.text('partition_col', '', '04 Source Partition Column')\n",
-    "dbutils.widgets.text('tgt_catalog', '', '05 Target Catalog')\n",
-    "dbutils.widgets.text('tgt_schema', '', '06 Target Schema')\n",
-    "dbutils.widgets.text('tgt_table', '', '07 Target Table')"
+    "dbutils.widgets.text('partition_size_mb', '', '05 Partition Size MB')\n",
+    "dbutils.widgets.text('tgt_catalog', '', '06 Target Catalog')\n",
+    "dbutils.widgets.text('tgt_schema', '', '07 Target Schema')\n",
+    "dbutils.widgets.text('tgt_table', '', '08 Target Table')"
    ]
   },
   {
@@ -60,10 +62,12 @@
    },
    "outputs": [],
    "source": [
+    "src_type = dbutils.widgets.get('src_type')\n",
     "src_catalog = dbutils.widgets.get('src_catalog')\n",
     "src_schema = dbutils.widgets.get('src_schema')\n",
     "src_table = dbutils.widgets.get('src_table')\n",
     "partition_col = dbutils.widgets.get('partition_col')\n",
+    "partition_size_mb = int(dbutils.widgets.get('partition_size_mb'))\n",
     "tgt_catalog = dbutils.widgets.get('tgt_catalog')\n",
     "tgt_schema = dbutils.widgets.get('tgt_schema')\n",
     "tgt_table = dbutils.widgets.get('tgt_table')"
@@ -87,12 +91,13 @@
    },
    "outputs": [],
    "source": [
-    "partition_spec = get_partition_spec_sqlserver(\n",
+    "partition_spec = get_partition_spec(\n",
+    "    src_type=src_type,\n",
     "    catalog=src_catalog,\n",
     "    schema=src_schema,\n",
     "    table=src_table,\n",
     "    partition_col=partition_col,\n",
-    "    partition_size_mb=200,\n",
+    "    partition_size_mb=partition_size_mb,\n",
     ")\n",
     "\n",
     "print(partition_spec)"
@@ -141,7 +146,7 @@
     "batch_list.sort()\n",
     "print(f'batch_list: {batch_list}')\n",
     "\n",
-    "# Assign batch list to job task value. The list can be iterated in a subsequent task.\n",
+    "# Assign batch list to job task value. The lvl1 job iterates over the batches.\n",
     "dbutils.jobs.taskValues.set(key=\"batch_list\", value=batch_list)"
    ]
   }

--- a/src/run_query_py.ipynb
+++ b/src/run_query_py.ipynb
@@ -61,11 +61,10 @@
     "spark.sql(f'use catalog {tgt_catalog}')\n",
     "spark.sql(f'use schema {tgt_schema}')\n",
     "\n",
-    "# Add build full statement\n",
+    "# Build sql statement\n",
     "qry = f'insert into {tgt_catalog}.{tgt_schema}.{tgt_table} select * from {src_catalog}.{src_schema}.{src_table} where {where_clause}'\n",
     "\n",
-    "print('Query:')\n",
-    "print(qry)\n",
+    "print(f'Query:\\n{qry}')\n",
     "\n",
     "display(spark.sql(qry))"
    ]


### PR DESCRIPTION
- Add support for PostgreSQL. The table size query is pushed down using JDBC because Lakehouse Federation does not support the pg_relation_size function.
- Refactor to make the source database type a parameter