### PR TITLE
Make create table DDL dynamic

### DIFF
--- a/config/ddl_create_lakefed_tgt.txt
+++ b/config/ddl_create_lakefed_tgt.txt
@@ -1,0 +1,15 @@
+create or replace table {catalog}.{schema}.{table} (
+  customer_id BIGINT,
+  name STRING,
+  alias STRING,
+  payment_instrument_type STRING,
+  payment_instrument STRING,
+  email STRING,
+  email2 STRING,
+  ip_address STRING,
+  md5_payment_instrument STRING,
+  customer_notes STRING,
+  created_ts TIMESTAMP,
+  modified_ts TIMESTAMP,
+  memo STRING)
+  CLUSTER BY ({partition_col})

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,9 +27,13 @@ wheel
 ## for this project.
 databricks-connect>=14.3,<14.4
 
+## Downgrade numpy due to issue below
+## AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.
+numpy<2.0
+
 ## jsonschema used to validate json. Used locally for unit tests
 ## Included in DBR so doesn't need to be installed separately
-jsonschema
+jsonschema==4.17.3
 
 ## Databricks SDK. Used for managing secrets in notebooks/manage_secrets.ipynb
 databricks-sdk==0.25.1

--- a/resources/lakefed_job.yml
+++ b/resources/lakefed_job.yml
@@ -48,6 +48,10 @@ resources:
           default: customer_id
         - name: partition_size_mb
           default: 256
+        - name: jdbc_config_file
+          default: ""
+        - name: tgt_ddl_file_path
+          default: config/ddl_create_lakefed_tgt.txt
         - name: tgt_catalog
           default: main
         - name: tgt_schema

--- a/src/create_tgt_table.ipynb
+++ b/src/create_tgt_table.ipynb
@@ -19,7 +19,18 @@
    "source": [
     "dbutils.widgets.text('catalog', '', '01 Catalog')\n",
     "dbutils.widgets.text('schema', '', '02 Schema')\n",
-    "dbutils.widgets.text('tgt_table', 'partitioned_queries_tgt', '03 Target Table')"
+    "dbutils.widgets.text('tgt_table', 'partitioned_queries_tgt', '03 Target Table')\n",
+    "dbutils.widgets.text('partition_col', '', '04 Partition Column')\n",
+    "dbutils.widgets.text('tgt_ddl_file_path', '', '05 Create target DDL file path')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lakefed_ingest.main import *"
    ]
   },
   {
@@ -42,9 +53,25 @@
     "catalog = dbutils.widgets.get('catalog')\n",
     "schema = dbutils.widgets.get('schema')\n",
     "tgt_table = dbutils.widgets.get('tgt_table')\n",
+    "partition_col = dbutils.widgets.get('partition_col')\n",
+    "file_path = dbutils.widgets.get('tgt_ddl_file_path')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sql_ddl = get_sql_ddl(\n",
+    "    catalog=catalog,\n",
+    "    schema=schema,\n",
+    "    table=tgt_table,\n",
+    "    partition_col=partition_col,\n",
+    "    file_path=file_path,\n",
+    ")\n",
     "\n",
-    "spark.sql(f'use catalog {catalog}')\n",
-    "spark.sql(f'create schema if not exists {schema}')"
+    "print(f'Create target table DDL statement:\\n{sql_ddl}')"
    ]
   },
   {
@@ -64,23 +91,7 @@
    },
    "outputs": [],
    "source": [
-    "create_tgt_table = f\"\"\"create or replace table {catalog}.{schema}.{tgt_table} (\n",
-    "  customer_id BIGINT,\n",
-    "  name STRING,\n",
-    "  alias STRING,\n",
-    "  payment_instrument_type STRING,\n",
-    "  payment_instrument STRING,\n",
-    "  email STRING,\n",
-    "  email2 STRING,\n",
-    "  ip_address STRING,\n",
-    "  md5_payment_instrument STRING,\n",
-    "  customer_notes STRING,\n",
-    "  created_ts TIMESTAMP,\n",
-    "  modified_ts TIMESTAMP,\n",
-    "  memo STRING)\n",
-    "  CLUSTER BY (customer_id)\"\"\"\n",
-    "\n",
-    "display(spark.sql(create_tgt_table))"
+    "display(spark.sql(sql_ddl))"
    ]
   }
  ],
@@ -181,7 +192,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,

--- a/src/get_partition_list.ipynb
+++ b/src/get_partition_list.ipynb
@@ -18,14 +18,15 @@
    "outputs": [],
    "source": [
     "dbutils.widgets.dropdown('src_type', 'sqlserver', ['sqlserver', 'postgresql', 'delta'], '01 Source Type')\n",
-    "dbutils.widgets.text('src_catalog', '', '01 Source Catalog')\n",
-    "dbutils.widgets.text('src_schema', '', '02 Source Schema')\n",
-    "dbutils.widgets.text('src_table', '', '03 Source Table')\n",
-    "dbutils.widgets.text('partition_col', '', '04 Source Partition Column')\n",
-    "dbutils.widgets.text('partition_size_mb', '', '05 Partition Size MB')\n",
-    "dbutils.widgets.text('tgt_catalog', '', '06 Target Catalog')\n",
-    "dbutils.widgets.text('tgt_schema', '', '07 Target Schema')\n",
-    "dbutils.widgets.text('tgt_table', '', '08 Target Table')"
+    "dbutils.widgets.text('src_catalog', '', '02 Source Catalog')\n",
+    "dbutils.widgets.text('src_schema', '', '03 Source Schema')\n",
+    "dbutils.widgets.text('src_table', '', '04 Source Table')\n",
+    "dbutils.widgets.text('jdbc_config_file', '', '05 Source Table')\n",
+    "dbutils.widgets.text('partition_col', '', '06 Source Partition Column')\n",
+    "dbutils.widgets.text('partition_size_mb', '', '07 Partition Size MB')\n",
+    "dbutils.widgets.text('tgt_catalog', '', '08 Target Catalog')\n",
+    "dbutils.widgets.text('tgt_schema', '', '09 Target Schema')\n",
+    "dbutils.widgets.text('tgt_table', '', '10 Target Table')"
    ]
   },
   {
@@ -66,11 +67,14 @@
     "src_catalog = dbutils.widgets.get('src_catalog')\n",
     "src_schema = dbutils.widgets.get('src_schema')\n",
     "src_table = dbutils.widgets.get('src_table')\n",
+    "jdbc_config_file = dbutils.widgets.get('jdbc_config_file')\n",
     "partition_col = dbutils.widgets.get('partition_col')\n",
     "partition_size_mb = int(dbutils.widgets.get('partition_size_mb'))\n",
     "tgt_catalog = dbutils.widgets.get('tgt_catalog')\n",
     "tgt_schema = dbutils.widgets.get('tgt_schema')\n",
-    "tgt_table = dbutils.widgets.get('tgt_table')"
+    "tgt_table = dbutils.widgets.get('tgt_table')\n",
+    "\n",
+    "jdbc_config_file = None if jdbc_config_file == '' else jdbc_config_file"
    ]
   },
   {
@@ -92,7 +96,7 @@
     "if src_type == 'sqlserver':\n",
     "    table_size_mb = get_table_size_sqlserver(src_catalog, src_schema, src_table)\n",
     "elif src_type == 'postgresql':\n",
-    "    table_size_mb = get_table_size_postgresql(src_catalog, src_schema, src_table, jdbc_config_file='config/postgresql_jdbc.json')\n",
+    "    table_size_mb = get_table_size_postgresql(src_catalog, src_schema, src_table, jdbc_config_file=jdbc_config_file)\n",
     "elif src_type == 'delta':\n",
     "    table_size_mb = get_table_size_delta(src_catalog, src_schema, src_table)\n",
     "else:\n",

--- a/tests/ddl_create_lakefed_tgt.txt
+++ b/tests/ddl_create_lakefed_tgt.txt
@@ -1,0 +1,5 @@
+create or replace table {catalog}.{schema}.{table} (
+  customer_id BIGINT,
+  name STRING,
+  alias STRING)
+  CLUSTER BY ({partition_col})

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,6 +1,7 @@
 from pyspark.testing import assertDataFrameEqual
 from jsonschema import exceptions
 import pytest
+import textwrap
 from lakefed_ingest.main import *
 
 # Partition list is scoped to module for multiple tests
@@ -50,3 +51,24 @@ def test_get_jdbc_config_fails() -> None:
 
     with pytest.raises(exceptions.ValidationError):
         get_jdbc_config(file_path='tests/jdbc_config_bad_schema.json')
+
+def test_get_sql_ddl():
+    expected_sql_ddl = f"""\
+        create or replace table main.lakefed.lakefed_tgt (
+          customer_id BIGINT,
+          name STRING,
+          alias STRING)
+          CLUSTER BY (customer_id)
+    """
+
+    expected_sql_ddl = textwrap.dedent(expected_sql_ddl)
+
+    sql_ddl = get_sql_ddl(
+        catalog='main',
+        schema='lakefed',
+        table='lakefed_tgt',
+        partition_col='customer_id',
+        file_path='tests/ddl_create_lakefed_tgt.txt',
+    )
+
+    assert sql_ddl == expected_sql_ddl


### PR DESCRIPTION
- Move create table DDL to file with placeholders for catalog, schema, table, and clustering column. This allows for setting the target table object name once at the job level.
- Add test for get_sql_ddl function