### PR TITLE
Add support for Redshift

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,5 @@
         "**/__pycache__": true,
         ".pytest_cache": true,
     },
-    "python.envFile": "${workspaceFolder}/.databricks/.databricks.env",
+    "python.envFile": "${workspaceRoot}/.env",
 }

--- a/notebooks/get_batch_of_partitions.ipynb
+++ b/notebooks/get_batch_of_partitions.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'batch_id: {batch_id}')\n",
+    "print(f'Batch id: {batch_id}')\n",
     "\n",
     "# TODO set partitions table suffix at job level\n",
     "partitions_tbl = f'{tgt_catalog}.{tgt_schema}.{tgt_table}_partitions'\n",

--- a/notebooks/get_partition_list.ipynb
+++ b/notebooks/get_partition_list.ipynb
@@ -17,7 +17,7 @@
    },
    "outputs": [],
    "source": [
-    "dbutils.widgets.dropdown('src_type', 'sqlserver', ['sqlserver', 'postgresql', 'delta'], '01 Source Type')\n",
+    "dbutils.widgets.dropdown('src_type', 'sqlserver', ['sqlserver', 'postgresql', 'redshift', 'delta'], '01 Source Type')\n",
     "dbutils.widgets.text('src_catalog', '', '02 Source Catalog')\n",
     "dbutils.widgets.text('src_schema', '', '03 Source Schema')\n",
     "dbutils.widgets.text('src_table', '', '04 Source Table')\n",

--- a/notebooks/get_partition_list.ipynb
+++ b/notebooks/get_partition_list.ipynb
@@ -99,6 +99,8 @@
     "    table_size_mb = get_table_size_sqlserver(src_catalog, src_schema, src_table)\n",
     "elif src_type == 'postgresql':\n",
     "    table_size_mb = get_table_size_postgresql(src_catalog, src_schema, src_table, root_dir, jdbc_config_file)\n",
+    "elif src_type == 'redshift':\n",
+    "    table_size_mb = get_table_size_redshift(src_catalog, src_schema, src_table)\n",
     "elif src_type == 'delta':\n",
     "    table_size_mb = get_table_size_delta(src_catalog, src_schema, src_table)\n",
     "else:\n",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,7 +25,7 @@ wheel
 ## to install the package system-wide. Or uncomment the line below to install a
 ## version of db-connect that corresponds to the Databricks Runtime version used
 ## for this project.
-databricks-connect>=14.3,<14.4
+databricks-connect>=15.4,<15.5
 
 ## Downgrade numpy due to issue below
 ## AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.
@@ -36,4 +36,4 @@ numpy<2.0
 jsonschema==4.23.0
 
 ## Databricks SDK. Used for managing secrets in notebooks/manage_secrets.ipynb
-databricks-sdk==0.25.1
+databricks-sdk==0.34.0

--- a/src/lakefed_ingest/main.py
+++ b/src/lakefed_ingest/main.py
@@ -16,7 +16,7 @@ import os
 import re
 
 # Get SparkSession
-# https://docs.databricks.com/dev-tools/databricks-connect.html.
+# https://docs.databricks.com/dev-tools/databricks-connect.html
 def get_spark() -> SparkSession:
     try:
         return DatabricksSession.builder.getOrCreate()
@@ -248,6 +248,31 @@ def get_table_size_postgresql(
         table_size_in_bytes = spark.sql(table_size_qry).collect()[0]['pg_table_size']
     
     table_size_mb = math.ceil(table_size_in_bytes / 1024 / 1024)
+    
+    return table_size_mb
+
+def get_table_size_redshift(catalog:str, schema:str, table:str) -> int:
+    """Get Redshift table size
+    
+    Args:
+        catalog (str): Catalog name
+        schema (str): Schema name
+        table (str): Table name
+    
+    Returns:
+        int: Size of Redshift table in MB
+    """
+    
+    table_size_qry = f"""\
+        select size as table_size_mb
+        from {catalog}.pg_catalog.svv_table_info
+        where schema = '{schema}'
+        and table = '{table}'
+    """
+    print(f'Query used to get table size:\n{textwrap.dedent(table_size_qry)}')
+    
+    spark.sql(f'use catalog {catalog}')
+    table_size_mb = spark.sql(table_size_qry).collect()[0]['table_size_mb']
     
     return table_size_mb
 


### PR DESCRIPTION
- Add function called get_table_size_redshift to src/lakefed_ingest/main.py. This function returns the table size in MB.
- Add elif condition to notebooks/get_partition_list.ipynb that refers to the Redshift function created above.
- Add "redshift" to the src_type widget in notebooks/get_partition_list.ipynb.
- Update Databricks Connect and SDK versions in requirements-dev.txt